### PR TITLE
Xor and Not fixes

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Not.cs
+++ b/source/Cosmos.IL2CPU/IL/Not.cs
@@ -1,24 +1,36 @@
 using System;
 
 using XSharp;
-using CPUx86 = XSharp.Assembler.x86;
+using static XSharp.XSRegisters;
 
 namespace Cosmos.IL2CPU.X86.IL
 {
-    [Cosmos.IL2CPU.OpCode( ILOpCode.Code.Not )]
+    [OpCode(ILOpCode.Code.Not)]
     public class Not : ILOp
     {
-        public Not( XSharp.Assembler.Assembler aAsmblr )
-            : base( aAsmblr )
+        public Not(XSharp.Assembler.Assembler aAsmblr)
+            : base(aAsmblr)
         {
         }
 
-        public override void Execute(_MethodInfo aMethod, ILOpCode aOpCode )
+        public override void Execute(_MethodInfo aMethod, ILOpCode aOpCode)
         {
-            XS.Pop(XSRegisters.EAX);
-            XS.Not(XSRegisters.EAX);
-            XS.Push(XSRegisters.EAX);
-        }
+            var xType = aOpCode.StackPopTypes[0];
+            var xSize = SizeOfType(xType);
 
+            if (xSize <= 4)
+            {
+                XS.Not(ESP, isIndirect: true);
+            }
+            else if (xSize <= 8)
+            {
+                XS.Not(ESP, isIndirect: true);
+                XS.Not(ESP, displacement: 4);
+            }
+            else
+            {
+                throw new NotImplementedException("Cosmos.IL2CPU.x86->IL->Not.cs->Error: StackSize > 8 not supported");
+            }
+        }
     }
 }

--- a/source/Cosmos.IL2CPU/IL/Xor.cs
+++ b/source/Cosmos.IL2CPU/IL/Xor.cs
@@ -1,26 +1,39 @@
 using System;
 
-using CPUx86 = XSharp.Assembler.x86;
-using Cosmos.IL2CPU.X86;
 using XSharp;
+using static XSharp.XSRegisters;
 
 namespace Cosmos.IL2CPU.X86.IL
 {
-    [Cosmos.IL2CPU.OpCode( ILOpCode.Code.Xor )]
+    [OpCode(ILOpCode.Code.Xor)]
     public class Xor : ILOp
     {
-        public Xor( XSharp.Assembler.Assembler aAsmblr )
-            : base( aAsmblr )
+        public Xor(XSharp.Assembler.Assembler aAsmblr)
+            : base(aAsmblr)
         {
         }
 
-        public override void Execute(_MethodInfo aMethod, ILOpCode aOpCode )
+        public override void Execute(_MethodInfo aMethod, ILOpCode aOpCode)
         {
-            var xSize = Math.Max(SizeOfType(aOpCode.StackPopTypes[0]), SizeOfType(aOpCode.StackPopTypes[1]));
-            XS.Pop(XSRegisters.EAX);
-            XS.Pop(XSRegisters.EDX);
-            XS.Xor(XSRegisters.EAX, XSRegisters.EDX);
-            XS.Push(XSRegisters.EAX);
+            var xType = aOpCode.StackPopTypes[0];
+            var xSize = SizeOfType(xType);
+
+            if (xSize <= 4)
+            {
+                XS.Pop(EAX);
+                XS.Xor(ESP, EAX, destinationIsIndirect: true);
+            }
+            else if (xSize <= 8)
+            {
+                XS.Pop(EAX);
+                XS.Pop(EDX);
+                XS.Xor(ESP, EAX, destinationIsIndirect: true);
+                XS.Xor(ESP, EDX, destinationDisplacement: 4);
+            }
+            else
+            {
+                throw new NotImplementedException("Cosmos.IL2CPU.x86->IL->Xor.cs->Error: StackSize > 8 not supported");
+            }
         }
     }
 }


### PR DESCRIPTION
Changes from https://github.com/CosmosOS/Cosmos/pull/674

## Changes
- Implemented Xor and Not for 8 byte operands.
- Optimized Xor and Not for 4 byte operands.