### PR TITLE
Fix Double Arrays

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
@@ -124,6 +124,8 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Stelem_I2:
         case Code.Stelem_I4:
         case Code.Stelem_I8:
+        case Code.Stelem_R4:
+        case Code.Stelem_R8:
           return 3;
         case Code.Shr:
         case Code.Shr_Un:
@@ -260,6 +262,8 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Stelem_I2:
         case Code.Stelem_I4:
         case Code.Stelem_I8:
+        case Code.Stelem_R4:
+        case Code.Stelem_R8:
         case Code.Stelem_Ref:
           return 0;
         case Code.Shr:


### PR DESCRIPTION
# **Changes:**
 - Implement **Stelem_R4** case in `OpNone.cs` since it does exist
 - Implement **Stelem_R8** case in `OpNone.cs` since it does exist
# **Test Code:**
 ```csharp
float[] mFloat = new float[16];
mFloat[5] = 0.28301;
mFloat[6] = 0.2894;
mFloat[11] = mFloat[5] + mFloat[6];
Console.WriteLine(mFloat[11]);

double[] mDouble = new double[16];
mDouble[5] = 0.28301;
mDouble[6] = 0.2894;
mDouble[11] = mDouble[5] + mDouble[6];
Console.WriteLine(mDouble[11]);
Console.ReadKey(true);
```
## **Output:**
![image](https://user-images.githubusercontent.com/22781491/34321686-61ab9484-e826-11e7-8a18-c2618332ab6c.png)
