### PR TITLE
VMT fixes

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Callvirt.cs
+++ b/source/Cosmos.IL2CPU/IL/Callvirt.cs
@@ -93,8 +93,18 @@ namespace Cosmos.IL2CPU.X86.IL
                     XS.Set(EAX, ESP, sourceDisplacement: (int)xThisOffset + 4);
                     XS.Push(EAX, isIndirect: true);
                 }
+
                 XS.Push(aTargetMethodUID);
-                XS.Call(LabelName.Get(VTablesImplRefs.GetMethodAddressForTypeRef));
+
+                if (aTargetMethod.DeclaringType.IsInterface)
+                {
+                    XS.Call(LabelName.Get(VTablesImplRefs.GetMethodAddressForInterfaceTypeRef));
+                }
+                else
+                {
+                    XS.Call(LabelName.Get(VTablesImplRefs.GetMethodAddressForTypeRef));
+                }
+
                 if (xExtraStackSize > 0)
                 {
                     xThisOffset -= xExtraStackSize;

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpMethod.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpMethod.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Reflection;
 
-
 namespace Cosmos.IL2CPU.ILOpCodes
 {
   public class OpMethod : ILOpCode
   {
     public MethodBase Value;
     public uint ValueUID;
-    public MethodBase BaseMethod;
-    public uint BaseMethodUID;
 
     public OpMethod(Code aOpCode, int aPos, int aNextPos, MethodBase aValue, _ExceptionRegionInfo aCurrentExceptionRegion)
       : base(aOpCode, aPos, aNextPos, aCurrentExceptionRegion)

--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -223,11 +223,13 @@ namespace Cosmos.IL2CPU
             // Pull in extra implementations, GC etc.
             Queue(RuntimeEngineRefs.InitializeApplicationRef, null, "Explicit Entry");
             Queue(RuntimeEngineRefs.FinalizeApplicationRef, null, "Explicit Entry");
-            Queue(VTablesImplRefs.SetTypeInfoRef, null, "Explicit Entry");
-            Queue(VTablesImplRefs.SetMethodInfoRef, null, "Explicit Entry");
-            Queue(VTablesImplRefs.SetInterfaceInfoRef, null, "Explicit Entry");
             Queue(VTablesImplRefs.IsInstanceRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetTypeInfoRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetInterfaceInfoRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetMethodInfoRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetInterfaceMethodInfoRef, null, "Explicit Entry");
             Queue(VTablesImplRefs.GetMethodAddressForTypeRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.GetMethodAddressForInterfaceTypeRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.IncRefCountRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.DecRefCountRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.AllocNewObjectRef, null, "Explicit Entry");
@@ -290,7 +292,10 @@ namespace Cosmos.IL2CPU
             Queue(VTablesImplRefs.SetMethodInfoRef, null, "Explicit Entry");
             Queue(VTablesImplRefs.IsInstanceRef, null, "Explicit Entry");
             Queue(VTablesImplRefs.SetTypeInfoRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetInterfaceInfoRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.SetInterfaceMethodInfoRef, null, "Explicit Entry");
             Queue(VTablesImplRefs.GetMethodAddressForTypeRef, null, "Explicit Entry");
+            Queue(VTablesImplRefs.GetMethodAddressForInterfaceTypeRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.IncRefCountRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.DecRefCountRef, null, "Explicit Entry");
             Queue(GCImplementationRefs.AllocNewObjectRef, null, "Explicit Entry");

--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -323,12 +323,10 @@ namespace Cosmos.IL2CPU
         {
             foreach (var xOpCode in aOpCodes)
             {
-                var xOpMethod = xOpCode as ILOpCodes.OpMethod;
-                if (xOpMethod != null)
+                if (xOpCode is ILOpCodes.OpMethod xOpMethod)
                 {
                     xOpMethod.Value = (MethodBase)mItems.GetItemInList(xOpMethod.Value);
-                    xOpMethod.ValueUID = GetMethodUID(xOpMethod.Value, true);
-                    xOpMethod.BaseMethodUID = GetMethodUID(xOpMethod.Value, false);
+                    xOpMethod.ValueUID = GetMethodUID(xOpMethod.Value);
                 }
             }
         }
@@ -816,100 +814,57 @@ namespace Cosmos.IL2CPU
             xList.Add(xLogItem);
         }
 
-        private MethodBase GetUltimateBaseMethod(MethodBase aMethod, Type[] aMethodParams, Type aCurrentInspectedType)
+        private MethodInfo GetUltimateBaseMethod(MethodInfo aMethod)
         {
-            MethodBase xInstanceBaseMethod = null;
-
-            Type xCurrentType = aCurrentInspectedType;
-            while (xCurrentType != null)
-            {
-                foreach (var xInterface in xCurrentType.GetInterfaces())
-                {
-                    var xInterfaceMap = xCurrentType.GetInterfaceMap(xInterface);
-                    var xMethod = xInterfaceMap.TargetMethods.SingleOrDefault(
-                            m => m.Name == aMethod.Name
-                              && m.GetParameters().Select(
-                                p => p.ParameterType).SequenceEqual(aMethodParams));
-
-                    if (xMethod != null && xMethod.DeclaringType == xCurrentType)
-                    {
-                        var xMethodIndex = Array.IndexOf(xInterfaceMap.TargetMethods, xMethod);
-
-                        if (xMethodIndex != -1)
-                        {
-                            return xInterfaceMap.InterfaceMethods[xMethodIndex];
-                        }
-                    }
-                }
-                xCurrentType = xCurrentType.BaseType;
-            }
+            var xBaseMethod = aMethod;
 
             while (true)
             {
-                if (aCurrentInspectedType.BaseType == null)
-                {
-                    break;
-                }
-                aCurrentInspectedType = aCurrentInspectedType.BaseType;
-                MethodBase xFoundMethod = aCurrentInspectedType
-                    .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                    .SingleOrDefault(method => method.Name == aMethod.Name
-                                               && method.GetParameters().Select(param => param.ParameterType)
-                                                   .SequenceEqual(aMethodParams));
-                if (xFoundMethod == null)
-                {
-                    break;
-                }
-                ParameterInfo[] xParams = xFoundMethod.GetParameters();
-                bool xContinue = true;
-                for (int i = 0; i < xParams.Length; i++)
-                {
-                    if (xParams[i].ParameterType != aMethodParams[i])
-                    {
-                        xContinue = false;
-                    }
-                }
-                if (!xContinue)
-                {
-                    continue;
-                }
-                xInstanceBaseMethod = xFoundMethod;
+                var xBaseDefinition = xBaseMethod.GetBaseDefinition();
 
-                if ((xFoundMethod.IsVirtual == aMethod.IsVirtual) && (xFoundMethod.IsPrivate == false) && (xFoundMethod.IsPublic == aMethod.IsPublic) && (xFoundMethod.IsFamily == aMethod.IsFamily) && (xFoundMethod.IsFamilyAndAssembly == aMethod.IsFamilyAndAssembly) && (xFoundMethod.IsFamilyOrAssembly == aMethod.IsFamilyOrAssembly) && (xFoundMethod.IsFinal == false))
+                if (xBaseDefinition == xBaseMethod)
                 {
-                    var xFoundMethInfo = (MethodInfo)xFoundMethod;
-                    var xBaseMethInfo = (MethodInfo)xInstanceBaseMethod;
-                    if (xFoundMethInfo.ReturnType.AssemblyQualifiedName.Equals(xBaseMethInfo.ReturnType.AssemblyQualifiedName))
-                    {
-                        xInstanceBaseMethod = xFoundMethod;
-                    }
+                    return xBaseMethod;
                 }
+
+                xBaseMethod = xBaseDefinition;
             }
-
-            return xInstanceBaseMethod ?? aMethod;
         }
 
-        protected uint GetMethodUID(MethodBase aMethod, bool aExact)
+        protected uint GetMethodUID(MethodBase aMethod)
         {
-            if (!aExact)
+            if (mMethodUIDs.TryGetValue(aMethod, out var xMethodUID))
             {
-                var xParamTypes = aMethod.GetParameters().Select(p => p.ParameterType).ToArray();
-                var xBaseMethod = GetUltimateBaseMethod(aMethod, xParamTypes, aMethod.DeclaringType);
-
-                if (!mMethodUIDs.ContainsKey(xBaseMethod))
+                return xMethodUID;
+            }
+            else
+            {
+                if (!aMethod.DeclaringType.IsInterface)
                 {
-                    var xId = (uint)mMethodUIDs.Count;
-                    mMethodUIDs.Add(xBaseMethod, xId);
+                    if (aMethod is MethodInfo xMethodInfo)
+                    {
+                        var xBaseMethod = GetUltimateBaseMethod(xMethodInfo);
+
+                        if (!mMethodUIDs.TryGetValue(xBaseMethod, out xMethodUID))
+                        {
+                            xMethodUID = (uint)mMethodUIDs.Count;
+                            mMethodUIDs.Add(xBaseMethod, xMethodUID);
+                        }
+
+                        if (!new MethodBaseComparer().Equals(aMethod, xBaseMethod))
+                        {
+                            mMethodUIDs.Add(aMethod, xMethodUID);
+                        }
+
+                        return xMethodUID;
+                    }
                 }
 
-                return mMethodUIDs[xBaseMethod];
+                xMethodUID = (uint)mMethodUIDs.Count;
+                mMethodUIDs.Add(aMethod, xMethodUID);
+
+                return xMethodUID;
             }
-            if (!mMethodUIDs.ContainsKey(aMethod))
-            {
-                var xId = (uint)mMethodUIDs.Count;
-                mMethodUIDs.Add(aMethod, xId);
-            }
-            return mMethodUIDs[aMethod];
         }
 
         protected uint GetTypeUID(Type aType)
@@ -1055,6 +1010,7 @@ namespace Cosmos.IL2CPU
 
             var xTypes = new HashSet<Type>();
             var xMethods = new HashSet<MethodBase>();
+
             foreach (var xItem in mItems)
             {
                 if (xItem is MethodBase)
@@ -1067,7 +1023,7 @@ namespace Cosmos.IL2CPU
                 }
             }
 
-            mAsmblr.GenerateVMTCode(xTypes, xMethods, GetTypeUID, x => GetMethodUID(x, false));
+            mAsmblr.GenerateVMTCode(xTypes, xMethods, GetTypeUID, GetMethodUID);
         }
     }
 }

--- a/source/Cosmos.IL2CPU/MemberInfoComparer.cs
+++ b/source/Cosmos.IL2CPU/MemberInfoComparer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using XSharp.Assembler;
+
+namespace Cosmos.IL2CPU
+{
+    internal class MemberInfoComparer : IEqualityComparer<MemberInfo>
+    {
+        public static MemberInfoComparer Instance { get; } = new MemberInfoComparer();
+
+        public bool Equals(MemberInfo x, MemberInfo y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+
+            if (y == null)
+            {
+                return false;
+            }
+
+            if (x.GetType() == y.GetType())
+            {
+                if (x.MetadataToken == y.MetadataToken && x.Module == y.Module)
+                {
+                    if (x is MethodBase xMethod && y is MethodBase yMethod)
+                    {
+                        return LabelName.GetFullName(xMethod) == LabelName.GetFullName(yMethod);
+                    }
+                    else if (x is Type xType && y is Type yType)
+                    {
+                        return LabelName.GetFullName(xType) == LabelName.GetFullName(yType);
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public int GetHashCode(MemberInfo obj) => obj.MetadataToken;
+    }
+}

--- a/source/Cosmos.IL2CPU/VTablesImplRefs.cs
+++ b/source/Cosmos.IL2CPU/VTablesImplRefs.cs
@@ -8,9 +8,11 @@ namespace Cosmos.IL2CPU
         public static readonly Assembly RuntimeAssemblyDef;
         public static readonly Type VTablesImplDef;
         public static readonly MethodBase SetTypeInfoRef;
-        public static readonly MethodBase SetMethodInfoRef;
         public static readonly MethodBase SetInterfaceInfoRef;
+        public static readonly MethodBase SetMethodInfoRef;
+        public static readonly MethodBase SetInterfaceMethodInfoRef;
         public static readonly MethodBase GetMethodAddressForTypeRef;
+        public static readonly MethodBase GetMethodAddressForInterfaceTypeRef;
         public static readonly MethodBase IsInstanceRef;
 
         static VTablesImplRefs()


### PR DESCRIPTION
## Changes
- Removed base method from `OpMethod`.
- Added a new type, `MemberInfoComparer`, which is an equality comparer for `MemberInfo` instances (there are special cases for `Type` and `MethodBase`, because of generics; it may have to be used in other places, because there may be weird bugs in the future caused by this ([`ReflectedType`](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.reflectedtype) is the problem)).
- `GetMethodUID` now returns the ultimate base method id.
- ~Interface method implementations are emitted side by side with normal methods (there may be more than an entry for the same method, as it may represent many different interface implementations).~
- Added arrays to `VTable` for interface methods.