### PR TITLE
Fixed value type field offset and size calculations

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Newobj.cs
+++ b/source/Cosmos.IL2CPU/IL/Newobj.cs
@@ -98,6 +98,11 @@ namespace Cosmos.IL2CPU.X86.IL
                 XS.Add(EAX, xArgSize + 4);
                 XS.Set(ESP, EAX, destinationDisplacement: (int)xArgSize);
 
+                XS.Push(EAX);
+
+                var xOpType = new OpType(xMethod.OpCode, xMethod.Position, xMethod.NextPosition, xMethod.Value.DeclaringType, xMethod.CurrentExceptionRegion);
+                new Initobj(aAssembler).Execute(aMethod, xOpType);
+
                 new Call(aAssembler).Execute(aMethod, xMethod);
 
                 // Need to put these *after* the call because the Call pops the args from the stack

--- a/source/Cosmos.IL2CPU/ILOp.cs
+++ b/source/Cosmos.IL2CPU/ILOp.cs
@@ -229,6 +229,23 @@ namespace Cosmos.IL2CPU
 
         public static List<_FieldInfo> GetFieldsInfo(Type aType, bool includeStatic)
         {
+            if (aType.IsValueType)
+            {
+                var fieldsInfo = GetValueTypeFieldsInfo(aType);
+
+                if (includeStatic)
+                {
+                    foreach (var field in aType.GetFields(
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+                    {
+                        fieldsInfo.Add(
+                            new _FieldInfo(field.GetFullName(), SizeOfType(field.FieldType), aType, field.FieldType));
+                    }
+                }
+
+                return fieldsInfo;
+            }
+
             var xResult = new List<_FieldInfo>(16);
             DoGetFieldsInfo(aType, xResult, includeStatic);
             xResult.Reverse();
@@ -261,6 +278,68 @@ namespace Cosmos.IL2CPU
             return xResult;
         }
 
+        private static List<_FieldInfo> GetValueTypeFieldsInfo(Type type)
+        {
+            var structLayoutAttribute = type.StructLayoutAttribute;
+            var fieldInfos = new List<_FieldInfo>();
+
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            switch (structLayoutAttribute.Value)
+            {
+                case LayoutKind.Auto:
+                case LayoutKind.Sequential:
+                    var offset = 0;
+                    var pack = structLayoutAttribute.Pack;
+
+                    if (pack == 0)
+                    {
+                        pack = (int)SizeOfType(typeof(IntPtr));
+                    }
+
+                    if (fields.Length > 0)
+                    {
+                        var typeAlignment = Math.Min(pack, fields.Max(f => SizeOfType(f.FieldType)));
+
+                        Array.Sort(fields, (x, y) => x.MetadataToken.CompareTo(y.MetadataToken));
+
+                        foreach (var field in fields)
+                        {
+                            var fieldSize = SizeOfType(field.FieldType);
+
+                            var fieldAlignment = Math.Min(typeAlignment, fieldSize);
+                            offset = (int)Align((uint)offset, (uint)fieldAlignment);
+
+                            var fieldInfo = new _FieldInfo(
+                                field.GetFullName(), SizeOfType(field.FieldType), type, field.FieldType);
+                            fieldInfo.Offset = (uint)offset;
+                            fieldInfo.Field = field;
+
+                            fieldInfos.Add(fieldInfo);
+
+                            offset += (int)fieldSize;
+                        }
+                    }
+
+                    break;
+                case LayoutKind.Explicit:
+                    foreach (var field in fields)
+                    {
+                        var fieldInfo = new _FieldInfo(field.GetFullName(), SizeOfType(field.FieldType), type, field.FieldType);
+                        fieldInfo.Offset = (uint)(field.GetCustomAttribute<FieldOffsetAttribute>()?.Value ?? 0);
+                        fieldInfo.Field = field;
+
+                        fieldInfos.Add(fieldInfo);
+                    }
+
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            return fieldInfos;
+        }
+
         private static void GetFieldMapping(List<_FieldInfo> aFieldInfs, List<DebugInfo.Field_Map> aFieldMapping,
           Type aType)
         {
@@ -289,6 +368,32 @@ namespace Cosmos.IL2CPU
 
         protected static uint GetStorageSize(Type aType)
         {
+            if (aType.IsValueType)
+            {
+                var structLayoutAttribute = aType.StructLayoutAttribute;
+                var pack = structLayoutAttribute.Pack;
+
+                if (pack == 0)
+                {
+                    pack = (int)SizeOfType(typeof(IntPtr));
+                }
+
+                var fieldsInfo = GetFieldsInfo(aType, false);
+
+                if (fieldsInfo.Count > 0)
+                {
+                    var typeAlignment = (uint)Math.Min(fieldsInfo.Max(f => f.Size), pack);
+
+                    return (uint)Math.Max(
+                        structLayoutAttribute.Size,
+                        Align(fieldsInfo.Max(f => f.Offset + f.Size), typeAlignment));
+                }
+                else
+                {
+                    return (uint)Math.Max(structLayoutAttribute.Size, 0);
+                }
+            }
+
             return (from item in GetFieldsInfo(aType, false)
                     where !item.IsStatic
                     orderby item.Offset descending
@@ -460,6 +565,14 @@ namespace Cosmos.IL2CPU
             return xFieldInfo;
         }
 
+        public static _FieldInfo ResolveField(FieldInfo fieldInfo)
+        {
+            var fieldsInfo = GetFieldsInfo(fieldInfo.DeclaringType, fieldInfo.IsStatic);
+            return fieldsInfo.SingleOrDefault(
+                f => MemberInfoComparer.Instance.Equals(f.Field, fieldInfo))
+                ?? ResolveField(fieldInfo.DeclaringType, fieldInfo.GetFullName(), !fieldInfo.IsStatic);
+        }
+
         protected static void CopyValue(XSRegisters.Register32 destination, int destinationDisplacement, XSRegisters.Register32 source, int sourceDisplacement, uint size)
         {
             for (int i = 0; i < (size / 4); i++)
@@ -587,12 +700,8 @@ namespace Cosmos.IL2CPU
             }
             if (aType.IsValueType)
             {
-                var xSla = aType.StructLayoutAttribute;
-                if ((xSla != null) && (xSla.Size > 0))
-                {
-                    return (uint)xSla.Size;
-                }
-                return (uint)(from item in GetFieldsInfo(aType, false) select (int)item.Size).Sum();
+                // structs are stored in the stack, so stack size = storage size
+                return GetStorageSize(aType);
             }
             return 4;
         }

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpType.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpType.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 
-
 namespace Cosmos.IL2CPU.ILOpCodes
 {
   public class OpType : ILOpCode
@@ -108,7 +107,7 @@ namespace Cosmos.IL2CPU.ILOpCodes
           StackPushTypes[0] = typeof(void*);
           return;
         case Code.Box:
-          if (Value.IsPrimitive)
+          if (Value.IsValueType)
           {
             StackPushTypes[0] = typeof(Box<>).MakeGenericType(Value);
           }
@@ -168,37 +167,6 @@ namespace Cosmos.IL2CPU.ILOpCodes
           return;
         default:
           break;
-      }
-    }
-
-    /// <summary>
-    /// Based on updated StackPopTypes, try to update
-    /// </summary>
-    protected override void DoInterpretStackTypes(ref bool aSituationChanged)
-    {
-      base.DoInterpretStackTypes(ref aSituationChanged);
-
-      switch (OpCode)
-      {
-        case Code.Box:
-          if (StackPushTypes[0] != null)
-          {
-            return;
-          }
-
-          if (StackPopTypes[0] == null)
-          {
-            return;
-          }
-
-          if (ILOp.IsIntegralType(StackPopTypes[0]) &&
-              ILOp.IsIntegralType(Value))
-          {
-            StackPushTypes[0] = typeof(Box<>).MakeGenericType(Value);
-            aSituationChanged = true;
-            return;
-          }
-          throw new Exception("Wrong poptype: " + StackPopTypes[0].FullName);
       }
     }
   }

--- a/tests/IL2CPU.Compiler.Tests/IL2CPU.Compiler.Tests.csproj
+++ b/tests/IL2CPU.Compiler.Tests/IL2CPU.Compiler.Tests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+        <PackageReference Include="Moq" Version="4.8.2" />
         <PackageReference Include="NUnit" Version="3.10.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     </ItemGroup>

--- a/tests/IL2CPU.Compiler.Tests/ILOpTests.cs
+++ b/tests/IL2CPU.Compiler.Tests/ILOpTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using Moq;
+using NUnit.Framework;
+
+using Cosmos.IL2CPU;
+
+namespace IL2CPU.Compiler.Tests
+{
+    [TestFixture(TestOf = typeof(ILOp))]
+    public class ILOpTests
+    {
+        [Test]
+        public void GetFieldsInfo_ForSequentialLayoutValueType_ReturnsCorrectOffsets()
+        {
+            var valueType = MockDefaultValueType(MockField(typeof(byte)), MockField(typeof(string)));
+            var fieldsInfo = ILOp.GetFieldsInfo(valueType, false);
+
+            Assert.That(fieldsInfo, Has.Count.EqualTo(2));
+
+            Assert.That(fieldsInfo[0].Offset, Is.EqualTo(0));
+            Assert.That(fieldsInfo[1].Offset, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void GetFieldsInfo_ForSequentialLayoutValueTypeWithPackEqualTo2_ReturnsCorrectOffsets()
+        {
+            var valueType = MockSequentialValueType(2, MockField(typeof(byte)), MockField(typeof(string)));
+            var fieldsInfo = ILOp.GetFieldsInfo(valueType, false);
+
+            Assert.That(fieldsInfo, Has.Count.EqualTo(2));
+
+            Assert.That(fieldsInfo[0].Offset, Is.EqualTo(0));
+            Assert.That(fieldsInfo[1].Offset, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void GetFieldsInfo_ForExplicitLayoutValueType_ReturnsCorrectOffsets()
+        {
+            var valueType = MockExplicitValueType(MockField(typeof(byte), 3), MockField(typeof(string), 3));
+            var fieldsInfo = ILOp.GetFieldsInfo(valueType, false);
+
+            Assert.That(fieldsInfo, Has.Count.EqualTo(2));
+
+            Assert.That(fieldsInfo[0].Offset, Is.EqualTo(3));
+            Assert.That(fieldsInfo[1].Offset, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void GetFieldsInfo_ForColorStruct_ReturnsCorrectOffsets()
+        {
+            var fieldsInfo = ILOp.GetFieldsInfo(typeof(Color), false);
+
+            Assert.That(fieldsInfo, Has.Count.EqualTo(4));
+
+            Assert.That(fieldsInfo[0].Offset, Is.EqualTo(0));
+            Assert.That(fieldsInfo[1].Offset, Is.EqualTo(8));
+            Assert.That(fieldsInfo[2].Offset, Is.EqualTo(16));
+            Assert.That(fieldsInfo[3].Offset, Is.EqualTo(18));
+        }
+
+        [Test]
+        public void SizeOfType_ForColorStruct_Returns24()
+        {
+            var size = ILOp.SizeOfType(typeof(Color));
+            Assert.That(size, Is.EqualTo(24));
+        }
+
+        private Type MockDefaultValueType(params Mock<FieldInfo>[] fieldTypes) =>
+            MockValueTypeFull(fieldMocks: fieldTypes);
+        private Type MockSequentialValueType(int pack, params Mock<FieldInfo>[] fieldTypes) =>
+            MockValueTypeFull(pack: pack, fieldMocks: fieldTypes);
+        private Type MockExplicitValueType(params Mock<FieldInfo>[] fieldTypes) =>
+            MockValueTypeFull(LayoutKind.Explicit, fieldMocks: fieldTypes);
+        private Type MockAutoValueType(int pack, params Mock<FieldInfo>[] fieldTypes) =>
+            MockValueTypeFull(LayoutKind.Auto, fieldMocks: fieldTypes);
+
+        private Type MockValueTypeFull(
+            LayoutKind layoutKind = LayoutKind.Sequential,
+            int pack = 0,
+            int size = 0,
+            params Mock<FieldInfo>[] fieldMocks)
+        {
+            var typeMock = new Mock<Type>();
+            typeMock.CallBase = true;
+
+            var structLayoutAttribute = new StructLayoutAttribute(layoutKind)
+            {
+                Pack = pack,
+                Size = size,
+            };
+
+            var fieldInfos = fieldMocks.Select(
+                m =>
+                {
+                    m.Setup(f => f.DeclaringType).Returns(typeMock.Object);
+                    return m.Object;
+                }).ToArray();
+
+            typeMock.Setup(t => t.BaseType).Returns(typeof(ValueType));
+            typeMock.Setup(t => t.StructLayoutAttribute).Returns(structLayoutAttribute);
+            typeMock.Setup(
+                t => t.GetFields(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                    .Returns(fieldInfos);
+
+            return typeMock.Object;
+        }
+
+        private Mock<FieldInfo> MockField(Type fieldType, int? fieldOffset = null)
+        {
+            var fieldInfoMock = new Mock<FieldInfo>();
+            fieldInfoMock.Setup(i => i.FieldType).Returns(fieldType);
+
+            if (fieldOffset.HasValue)
+            {
+                var fieldOffsetAttribute = new FieldOffsetAttribute(fieldOffset.Value);
+                fieldInfoMock.Setup(f => f.GetCustomAttributes(typeof(FieldOffsetAttribute), true))
+                    .Returns(new[] { fieldOffsetAttribute });
+            }
+
+            return fieldInfoMock;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12.

## Changes
- Added missing calculations for struct fields.
- Fixed `ldfld` and `newobj`.
- Fixed stack push type for box in `OpType`.
- Added tests.