### PR TITLE
Added support for Unsafe intrinsics

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Unaligned.cs
+++ b/source/Cosmos.IL2CPU/IL/Unaligned.cs
@@ -12,7 +12,7 @@ namespace Cosmos.IL2CPU.X86.IL
 
         public override void Execute(_MethodInfo aMethod, ILOpCode aOpCode)
         {
-            throw new NotImplementedException("TODO: Unaligned");
+            //throw new NotImplementedException("TODO: Unaligned");
         }
     }
 }

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpInt.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpInt.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using System.Reflection.Metadata;
 
 
 namespace Cosmos.IL2CPU.ILOpCodes {
@@ -18,6 +17,8 @@ namespace Cosmos.IL2CPU.ILOpCodes {
       {
         case Code.Ldc_I4:
           return 0;
+        case Code.Unaligned:
+          return 0;
         default:
           throw new NotImplementedException("OpCode '" + OpCode + "' not implemented!");
       }
@@ -29,6 +30,8 @@ namespace Cosmos.IL2CPU.ILOpCodes {
       {
         case Code.Ldc_I4:
           return 1;
+        case Code.Unaligned:
+          return 0;
         default:
           throw new NotImplementedException("OpCode '" + OpCode + "' not implemented!");
       }

--- a/source/Cosmos.IL2CPU/ILReader.cs
+++ b/source/Cosmos.IL2CPU/ILReader.cs
@@ -1,9 +1,10 @@
-﻿using Cosmos.IL2CPU.Extensions;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+
+using Cosmos.IL2CPU.Extensions;
 
 namespace Cosmos.IL2CPU
 {
@@ -52,6 +53,15 @@ namespace Cosmos.IL2CPU
         {
             var xResult = new List<ILOpCode>();
             var xBody = aMethod.GetMethodBody();
+
+            if (aMethod.DeclaringType.FullName == "System.Runtime.CompilerServices.Unsafe")
+            {
+                xBody = Type.GetType(
+                    "System.Runtime.CompilerServices.Unsafe, System.Runtime.CompilerServices.Unsafe")
+                    .GetMethod(aMethod.Name, Array.ConvertAll(aMethod.GetParameters(), p => p.ParameterType))
+                    .GetMethodBody();
+            }
+
             // Cache for use in field and method resolution
             Type[] xTypeGenArgs = Type.EmptyTypes;
             Type[] xMethodGenArgs = Type.EmptyTypes;


### PR DESCRIPTION
## Changes
- Added support for `Unsafe` intrinsics.

This is not really the correct way of implementing it, but it avoids many plugs. On .NET Core 2.1, intrinsics are marked with the `Intrinsic` attribute, on .NET Core 2.0 we have to check the type namespace and name and implement the IL instructions for it. As there are two `Unsafe` implementations (one on coreclr and the other one on corefx), we can just pull the body of the corefx methods and replace the body of the coreclr ones for now.