### PR TITLE
Allow usage of Unsafe

### DIFF
--- a/source/Cosmos.IL2CPU/Cosmos.IL2CPU.csproj
+++ b/source/Cosmos.IL2CPU/Cosmos.IL2CPU.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
         <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
         <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
         <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     </ItemGroup>
 

--- a/source/Cosmos.IL2CPU/IL/Ldobj.cs
+++ b/source/Cosmos.IL2CPU/IL/Ldobj.cs
@@ -32,6 +32,20 @@ namespace Cosmos.IL2CPU.X86.IL
             XS.Pop(EAX);
             var xObjSize = SizeOfType(type);
 
+            if(xObjSize < 4 && IsIntegerSigned(type))
+            {
+              if(xObjSize == 1)
+              {
+                XS.MoveSignExtend(EBX, EAX, sourceIsIndirect: true, size: RegisterSize.Byte8);
+              }
+              else if (xObjSize == 2)
+              {
+                XS.MoveSignExtend(EBX, EAX, sourceIsIndirect: true, size: RegisterSize.Short16);
+              }
+              XS.Push(EBX);
+              return;
+            } 
+
             switch (xObjSize % 4)
             {
                 case 1:


### PR DESCRIPTION
Included System.Runtime.CompilerServices.Unsafe
Fixed handling of unsafe methods in ILReader for unsafe methods
This PR also fixes Ldobj to correctly handle sign extension