### PR TITLE
Added a work-around for IsClass not being true for EqualityComparer<T>.

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCodes/OpBranch.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpBranch.cs
@@ -184,6 +184,13 @@ namespace Cosmos.IL2CPU.ILOpCodes
             return;
           }
 
+          //EqualityComparer<> isn't detected as a class.
+          if (xValue1.IsGenericType &&
+              xValue2.IsGenericType)
+          {
+            return;
+          }
+
           if (xValue1.IsInterface && xValue1.IsAssignableFrom(xValue2) ||
               xValue2.IsInterface && xValue2.IsAssignableFrom(xValue1))
           {


### PR DESCRIPTION
This honestly shouldn't be needed as EqualityComparer<T> is a class and IsClass should return true for a generic anyway. However in my testing IsClass is false and this causes the constructor for dictionary to fail to build.

This update along with the related CosmosOS PR resolve issue #584.