### PR TITLE
Fix unconditional branch stack corruption

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCode.cs
+++ b/source/Cosmos.IL2CPU/ILOpCode.cs
@@ -419,6 +419,7 @@ namespace Cosmos.IL2CPU
       {
         throw new Exception("Error interpreting stacktypes for " + this, E);
       }
+
       foreach (var xPushItem in StackPushTypes)
       {
         aStack.Push(xPushItem);
@@ -431,7 +432,7 @@ namespace Cosmos.IL2CPU
     /// </summary>
     protected virtual void DoInterpretStackTypes(ref bool aSituationChanged)
     {
-      //
+      // This is implemented by different groups of op codes
     }
 
     protected virtual void DoInterpretNextInstructionStackTypesIfNotYetProcessed(IDictionary<int, ILOpCode> aOpCodes, Stack<Type> aStack, ref bool aSituationChanged, int aMaxRecursionDepth)

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpBranch.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpBranch.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -206,14 +205,15 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Bge_Un:
         case Code.Beq:
         case Code.Bne_Un:
-        case Code.Br:
-          InterpretInstructionIfNotYetProcessed(Value, aOpCodes, new Stack<Type>(aStack.Reverse()), ref aSituationChanged, aMaxRecursionDepth);
-          base.DoInterpretNextInstructionStackTypesIfNotYetProcessed(aOpCodes, new Stack<Type>(aStack.Reverse()), ref aSituationChanged, aMaxRecursionDepth);
-          break;
         case Code.Leave:
           InterpretInstructionIfNotYetProcessed(Value, aOpCodes, new Stack<Type>(aStack.Reverse()), ref aSituationChanged, aMaxRecursionDepth);
           base.DoInterpretNextInstructionStackTypesIfNotYetProcessed(aOpCodes, new Stack<Type>(aStack.Reverse()), ref aSituationChanged, aMaxRecursionDepth);
-
+          break;
+        case Code.Br: //An unconditional branch will never not branch, so we dont interpret stack if we didnt branch (as done for other branches)
+                      // Otherwise, this can lead to bugs, as the opcode after an unconditional branch is reached via a jump with a different stack, than the one
+                      // in the block ending with the unconditional branch before.
+                      // Can be reproduced by trying to compile this code: `char c2 = (c <= 'Z' && c >= 'A') ? ((char)(c - 65 + 97)) : c;`
+          InterpretInstructionIfNotYetProcessed(Value, aOpCodes, new Stack<Type>(aStack.Reverse()), ref aSituationChanged, aMaxRecursionDepth);
           break;
         default:
           throw new NotImplementedException("OpCode " + OpCode);


### PR DESCRIPTION
 An unconditional branch will never not branch, so we dont interpret stack if we didnt branch (as done for other branches. Otherwise, this can lead to bugs, as the opcode after an unconditional branch is reached via a jump with a different stack, than the one in the block ending with the unconditional branch before. Can be reproduced by trying to compile this code: `char c2 = (c <= 'Z' && c >= 'A') ? ((char)(c - 65 + 97)) : c;`