### PR TITLE
Fix stack corruptions due to incorrect NASM comments 

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Ldstr.cs
+++ b/source/Cosmos.IL2CPU/IL/Ldstr.cs
@@ -21,7 +21,7 @@ namespace Cosmos.IL2CPU.X86.IL
         {
             var xOpString = aOpCode as OpString;
             string xDataName = GetContentsArrayName(xOpString.Value);
-            XS.Comment("String Value: " + xOpString.Value.Replace("\r", "\\r").Replace("\n", "\\n"));
+            XS.Comment("String Value: \"" + xOpString.Value.Replace("\r", "\\r").Replace("\n", "\\n") + "\"");
             XS.Push(xDataName);
             XS.Push(0);
 


### PR DESCRIPTION
Fixes stack corruptions introduced by #93 due to strings with backslashes marking lines as comments in NASM, which prevented them from compiling, leading to incorrect asm being emitted for ldstr.