### PR TITLE
Update OpField.cs

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCodes/OpField.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpField.cs
@@ -186,6 +186,10 @@ namespace Cosmos.IL2CPU.ILOpCodes
           {
             return;
           }
+          if(StackPopTypes[0] == typeof(void*))
+          {
+          return;
+          }
           expectedType = Value.FieldType;
           if (expectedType.IsEnum)
           {


### PR DESCRIPTION
if we encounter a void* we return so the new memorymanagement in cosmos compiles in users Kernel instead of throwing a error about getting void* but expecting void**