### PR TITLE
Ignore missing VBE flag in csproj during compile

### DIFF
--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -171,7 +171,25 @@ namespace Cosmos.IL2CPU
                             xAsm.ShouldOptimize = true;
                         }
 
-                        xAsm.Assembler.Initialize(mSettings.CompileVBEMultiboot, mSettings.VBEResolution);
+                        bool VBEMultiboot = false;
+                        string VBEResolution;
+                        if(mSettings.CompileVBEMultiboot)
+                        {
+                            VBEMultiboot = true;
+                        }
+                        else
+                        {
+                            VBEMultiboot = false;
+                        }
+                        if(String.IsNullOrEmpty(mSettings.VBEResolution))
+                        {
+                            VBEResolution = "800x600x32";
+                        }
+                        else
+                        {
+                            VBEResolution=mSettings.VBEResolution;
+                        }
+                        xAsm.Assembler.Initialize(VBEMultiboot, VBEResolution);
 
                         if (mSettings.DebugMode != DebugMode.IL)
                         {


### PR DESCRIPTION
Fixes IL2CPU crash when the VBE parameters are missing in the .csproj file