### PR TITLE
Add IsStruct to VTablesImpl

### DIFF
--- a/source/Cosmos.IL2CPU/VTablesImplRefs.cs
+++ b/source/Cosmos.IL2CPU/VTablesImplRefs.cs
@@ -16,6 +16,7 @@ namespace Cosmos.IL2CPU
         public static readonly MethodBase GetDeclaringTypeOfMethodForTypeRef;
         public static readonly MethodBase IsInstanceRef;
         public static readonly MethodBase GetBaseTypeRef;
+        public static readonly MethodBase IsStructRef;
 
         public static Func<Type, uint> GetTypeId;
         // GC Methods

--- a/source/IL2CPU.API/ObjectUtils.cs
+++ b/source/IL2CPU.API/ObjectUtils.cs
@@ -2,68 +2,34 @@ using System;
 
 namespace IL2CPU.API
 {
-  public static class ObjectUtils
-  {
-    /// <summary>
-    ///		<para>
-    ///			The object first stores any metadata involved. (Most likely containing a reference to the
-    ///			object type). This is the number of bytes.
-    ///		</para>
-    ///		<para>
-    ///			The first 4 bytes are the reference to the type information of the instance,
-    ///         the second 4 bytes are the <see cref="InstanceTypeEnum"/> value.
-    ///         For arrays, there are 4 following bytes containing the element count,
-    ///         for objects, the amount of reference fields.
-    ///         For arrays, next 4 bytes containing the element size.
-    ///		</para>
-    /// </summary>
-    public const int FieldDataOffset = 12;
-
-    public enum InstanceTypeEnum : uint
+    public static class ObjectUtils
     {
-      NormalObject = 1,
+        /// <summary>
+        ///		<para>
+        ///			The object first stores any metadata involved. (Most likely containing a reference to the
+        ///			object type). This is the number of bytes.
+        ///		</para>
+        ///		<para>
+        ///			The first 4 bytes are the reference to the type information of the instance,
+        ///         the second 4 bytes are the <see cref="InstanceTypeEnum"/> value.
+        ///         For arrays, there are 4 following bytes containing the element count,
+        ///         for objects, the amount of reference fields.
+        ///         For arrays, next 4 bytes containing the element size.
+        ///		</para>
+        /// </summary>
+        public const int FieldDataOffset = 12;
 
-      Array = 2,
+        public enum InstanceTypeEnum : uint
+        {
+            NormalObject = 1,
 
-      BoxedValueType = 3,
+            Array = 2,
 
-      StaticEmbeddedObject = 0x80000001,
+            BoxedValueType = 3,
 
-      StaticEmbeddedArray = 0x80000002
+            StaticEmbeddedObject = 0x80000001,
+
+            StaticEmbeddedArray = 0x80000002
+        }
     }
-
-    public static bool IsDelegate(Type aType)
-    {
-      if (aType.FullName == "System.Object")
-      {
-        return false;
-      }
-      if (aType.BaseType.FullName == "System.Delegate")
-      {
-        return true;
-      }
-      if (aType.BaseType.FullName == "System.Object")
-      {
-        return false;
-      }
-      return IsDelegate(aType.BaseType);
-    }
-
-    public static bool IsArray(Type aType)
-    {
-      if (aType.FullName == "System.Object")
-      {
-        return false;
-      }
-      if (aType.BaseType.FullName == "System.Array")
-      {
-        return true;
-      }
-      if (aType.BaseType.FullName == "System.Object")
-      {
-        return false;
-      }
-      return IsArray(aType.BaseType);
-    }
-  }
 }


### PR DESCRIPTION
Clean up object utils

Required for delegates with return types