### PR TITLE
Added Remove Debug Output Option

### DIFF
--- a/source/Cosmos.IL2CPU/AppAssembler.cs
+++ b/source/Cosmos.IL2CPU/AppAssembler.cs
@@ -1371,7 +1371,7 @@ namespace Cosmos.IL2CPU
             }
             else
             {
-                X86.IL.Call.DoExecute(Assembler, null, aEntrypoint.DeclaringType.BaseType.GetMethod(CompilerEngine.UseGen3Kernel ? "EntryPoint" : "Start"), null, xCurLabel, CosmosAssembler.EntryPointName + ".AfterStart", DebugEnabled);
+                X86.IL.Call.DoExecute(Assembler, null, aEntrypoint.DeclaringType.GetMethod(CompilerEngine.UseGen3Kernel ? "EntryPoint" : "Start"), null, xCurLabel, CosmosAssembler.EntryPointName + ".AfterStart", DebugEnabled);
             }
             XS.Label(CosmosAssembler.EntryPointName + ".AfterStart");
             XS.Pop(EBP);

--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -189,7 +189,7 @@ namespace Cosmos.IL2CPU
                         {
                             VBEResolution=mSettings.VBEResolution;
                         }
-                        xAsm.Assembler.EnableLittleOptimization = mSettings.EnableLittleOptimization;
+                        xAsm.Assembler.RemoveBootDebugOutput = mSettings.RemoveBootDebugOutput;
                         xAsm.Assembler.Initialize(VBEMultiboot, VBEResolution);
 
                         if (mSettings.DebugMode != DebugMode.IL)

--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -189,7 +189,7 @@ namespace Cosmos.IL2CPU
                         {
                             VBEResolution=mSettings.VBEResolution;
                         }
-                        xAsm.Assembler.EnableFastBoost = mSettings.EnableFastBoost;
+                        xAsm.Assembler.EnableLittleOptimization = mSettings.EnableLittleOptimization;
                         xAsm.Assembler.Initialize(VBEMultiboot, VBEResolution);
 
                         if (mSettings.DebugMode != DebugMode.IL)

--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -189,6 +189,7 @@ namespace Cosmos.IL2CPU
                         {
                             VBEResolution=mSettings.VBEResolution;
                         }
+                        xAsm.Assembler.EnableFastBoost = mSettings.EnableFastBoost;
                         xAsm.Assembler.Initialize(VBEMultiboot, VBEResolution);
 
                         if (mSettings.DebugMode != DebugMode.IL)

--- a/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
@@ -40,7 +40,7 @@ namespace Cosmos.IL2CPU
 
         private Dictionary<string, string> mCmdOptions;
 
-        public bool EnableFastBoost => GetOption<bool>(nameof(EnableFastBoost));
+        public bool EnableLittleOptimization => GetOption<bool>(nameof(EnableLittleOptimization));
         public bool CompileVBEMultiboot => GetOption<bool>(nameof(CompileVBEMultiboot));
         public string VBEResolution => GetOption<string>(nameof(VBEResolution));
 

--- a/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
@@ -40,6 +40,7 @@ namespace Cosmos.IL2CPU
 
         private Dictionary<string, string> mCmdOptions;
 
+        public bool EnableFastBoost => GetOption<bool>(nameof(EnableFastBoost));
         public bool CompileVBEMultiboot => GetOption<bool>(nameof(CompileVBEMultiboot));
         public string VBEResolution => GetOption<string>(nameof(VBEResolution));
 

--- a/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
@@ -40,7 +40,7 @@ namespace Cosmos.IL2CPU
 
         private Dictionary<string, string> mCmdOptions;
 
-        public bool EnableLittleOptimization => GetOption<bool>(nameof(EnableLittleOptimization));
+        public bool RemoveBootDebugOutput => GetOption<bool>(nameof(RemoveBootDebugOutput));
         public bool CompileVBEMultiboot => GetOption<bool>(nameof(CompileVBEMultiboot));
         public string VBEResolution => GetOption<string>(nameof(VBEResolution));
 

--- a/source/Cosmos.IL2CPU/CosmosAssembler.cs
+++ b/source/Cosmos.IL2CPU/CosmosAssembler.cs
@@ -30,6 +30,8 @@ namespace Cosmos.IL2CPU
         public static bool ReadDebugStubFromDisk = true;
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        public bool EnableFastBoost = false;
+
         public virtual void WriteDebugVideo(string aText)
         {
             // This method emits a lot of ASM, but thats what we want becuase
@@ -38,7 +40,7 @@ namespace Cosmos.IL2CPU
 
             // TODO: Add an option on the debug project properties to turn this off.
             // Also see TokenPatterns.cs Checkpoint in X#
-            var xPreBootLogging = true;
+            var xPreBootLogging = EnableFastBoost;
             if (xPreBootLogging)
             {
                 new Comment("DebugVideo '" + aText + "'");

--- a/source/Cosmos.IL2CPU/CosmosAssembler.cs
+++ b/source/Cosmos.IL2CPU/CosmosAssembler.cs
@@ -30,7 +30,7 @@ namespace Cosmos.IL2CPU
         public static bool ReadDebugStubFromDisk = true;
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
-        public bool EnableFastBoost = false;
+        public bool EnableLittleOptimization = false;
 
         public virtual void WriteDebugVideo(string aText)
         {
@@ -40,7 +40,7 @@ namespace Cosmos.IL2CPU
 
             // TODO: Add an option on the debug project properties to turn this off.
             // Also see TokenPatterns.cs Checkpoint in X#
-            var xPreBootLogging = EnableFastBoost;
+            var xPreBootLogging = EnableLittleOptimization;
             if (xPreBootLogging)
             {
                 new Comment("DebugVideo '" + aText + "'");

--- a/source/Cosmos.IL2CPU/CosmosAssembler.cs
+++ b/source/Cosmos.IL2CPU/CosmosAssembler.cs
@@ -30,7 +30,7 @@ namespace Cosmos.IL2CPU
         public static bool ReadDebugStubFromDisk = true;
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
-        public bool EnableLittleOptimization = false;
+        public bool RemoveBootDebugOutput = false;
 
         public virtual void WriteDebugVideo(string aText)
         {
@@ -40,7 +40,7 @@ namespace Cosmos.IL2CPU
 
             // TODO: Add an option on the debug project properties to turn this off.
             // Also see TokenPatterns.cs Checkpoint in X#
-            var xPreBootLogging = EnableLittleOptimization;
+            var xPreBootLogging = RemoveBootDebugOutput;
             if (xPreBootLogging)
             {
                 new Comment("DebugVideo '" + aText + "'");

--- a/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
@@ -26,7 +26,7 @@ namespace Cosmos.IL2CPU
 
         string OutputFilename { get; }
 
-        bool EnableFastBoost { get; }
+        bool EnableLittleOptimization { get; }
         bool CompileVBEMultiboot { get; }
         string VBEResolution { get;  }
     }

--- a/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
@@ -26,7 +26,7 @@ namespace Cosmos.IL2CPU
 
         string OutputFilename { get; }
 
-        bool EnableLittleOptimization { get; }
+        bool RemoveBootDebugOutput { get; }
         bool CompileVBEMultiboot { get; }
         string VBEResolution { get;  }
     }

--- a/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
@@ -26,6 +26,7 @@ namespace Cosmos.IL2CPU
 
         string OutputFilename { get; }
 
+        bool EnableFastBoost { get; }
         bool CompileVBEMultiboot { get; }
         string VBEResolution { get;  }
     }


### PR DESCRIPTION
If the option enabled the compiler run faster,
The fast boost also remove more than 1000 lines of code in the final asm file