### PR TITLE
Get the full path for an assembly reference

### DIFF
--- a/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
@@ -137,10 +137,12 @@ namespace Cosmos.IL2CPU
 
                 if (String.Equals(key, "References", StringComparison.OrdinalIgnoreCase))
                 {
+                    value = Path.GetFullPath(value);
                     mReferences.Add(value);
                 }
                 else if (String.Equals(key, "PlugsReferences", StringComparison.OrdinalIgnoreCase))
                 {
+                    value = Path.GetFullPath(value);
                     mPlugsReferences.Add(value);
                 }
                 else if (String.Equals(key, "AssemblySearchDirs", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixes CosmosOS/Cosmos#2300