### PR TITLE
Reduce usage of plug trampoline code

### DIFF
--- a/source/Cosmos.IL2CPU/AppAssembler.cs
+++ b/source/Cosmos.IL2CPU/AppAssembler.cs
@@ -722,7 +722,7 @@ namespace Cosmos.IL2CPU
         private static Type VTableType;
         private static Type GCTableType;
 
-        public unsafe void GenerateVMTCode(HashSet<Type> aTypesSet, HashSet<MethodBase> aMethodsSet, Func<Type, uint> aGetTypeID, Func<MethodBase, uint> aGetMethodUID)
+        public unsafe void GenerateVMTCode(HashSet<Type> aTypesSet, HashSet<MethodBase> aMethodsSet, PlugManager aPlugManager, Func<Type, uint> aGetTypeID, Func<MethodBase, uint> aGetMethodUID)
         {
             XS.Comment("---------------------------------------------------------");
             XS.Label(InitVMTCodeLabel);
@@ -959,6 +959,9 @@ namespace Cosmos.IL2CPU
                 {
                     var xMethod = xEmittedMethods[j];
                     var xMethodUID = aGetMethodUID(xMethod);
+                    if (aPlugManager.DirectPlugMapping.TryGetValue(LabelName.GetFullName(xMethod), out MethodBase plug)){
+                        xMethodUID = aGetMethodUID(plug);
+                    }
 #if VMT_DEBUG
                         xVmtDebugOutput.WriteStartElement("Method");
                         xVmtDebugOutput.WriteAttributeString("Id", xMethodUID.ToString());

--- a/source/Cosmos.IL2CPU/IL/Call.cs
+++ b/source/Cosmos.IL2CPU/IL/Call.cs
@@ -92,6 +92,12 @@ namespace Cosmos.IL2CPU.X86.IL
         {
             var xMethodInfo = aTargetMethod as MethodInfo;
             string xNormalAddress = LabelName.Get(aTargetMethod);
+            if (PlugManager.DirectPlugMapping.ContainsKey(LabelName.GetFullName(aTargetMethod)))
+            {
+                string xPlugAddress = LabelName.Get(PlugManager.DirectPlugMapping[LabelName.GetFullName(aTargetMethod)]);
+                XS.Comment($"Redirecting call to {xNormalAddress} directly to plug {xPlugAddress}");
+                xNormalAddress = xPlugAddress;
+            }
             var xParameters = aTargetMethod.GetParameters();
 
             // todo: implement exception support

--- a/source/Cosmos.IL2CPU/ILOp.cs
+++ b/source/Cosmos.IL2CPU/ILOp.cs
@@ -90,12 +90,6 @@ namespace Cosmos.IL2CPU
             return GetType().Name;
         }
 
-        protected static void Jump_Exception(Il2cpuMethodInfo aMethod)
-        {
-            // todo: port to numeric labels
-            XS.Jump(GetLabel(aMethod) + AppAssembler.EndOfMethodLabelNameException);
-        }
-
         protected static void Jump_End(Il2cpuMethodInfo aMethod)
         {
             XS.Jump(GetLabel(aMethod) + AppAssembler.EndOfMethodLabelNameNormal);

--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -983,7 +983,7 @@ namespace Cosmos.IL2CPU
                                 if (xInstructions != null)
                                 {
                                     ProcessInstructions(xInstructions);
-                                    mAsmblr.ProcessMethod(xPlugInfo, xInstructions);
+                                    mAsmblr.ProcessMethod(xPlugInfo, xInstructions, mPlugManager);
                                 }
                             }
                             mAsmblr.GenerateMethodForward(xMethodInfo, xPlugInfo);
@@ -1006,7 +1006,7 @@ namespace Cosmos.IL2CPU
                                 if (xInstructions != null)
                                 {
                                     ProcessInstructions(xInstructions);
-                                    mAsmblr.ProcessMethod(xPlugInfo, xInstructions);
+                                    mAsmblr.ProcessMethod(xPlugInfo, xInstructions, mPlugManager);
                                 }
                                 mAsmblr.GenerateMethodForward(xMethodInfo, xPlugInfo);
                             }
@@ -1041,7 +1041,7 @@ namespace Cosmos.IL2CPU
                         if (xInstructions != null)
                         {
                             ProcessInstructions(xInstructions);
-                            mAsmblr.ProcessMethod(xMethodInfo, xInstructions);
+                            mAsmblr.ProcessMethod(xMethodInfo, xInstructions, mPlugManager);
                         }
                     }
                 }

--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -1065,7 +1065,7 @@ namespace Cosmos.IL2CPU
                 }
             }
 
-            mAsmblr.GenerateVMTCode(xTypes, xMethods, GetTypeUID, GetMethodUID);
+            mAsmblr.GenerateVMTCode(xTypes, xMethods, mPlugManager, GetTypeUID, GetMethodUID);
         }
     }
 }

--- a/source/Cosmos.IL2CPU/PlugManager.cs
+++ b/source/Cosmos.IL2CPU/PlugManager.cs
@@ -46,10 +46,11 @@ namespace Cosmos.IL2CPU
 
         private Dictionary<string, MethodBase> ResolvedPlugs = new Dictionary<string, MethodBase>();
 
-        private static string BuildMethodKeyName(MethodBase m)
-        {
-            return LabelName.GetFullName(m);
-        }
+        /// <summary>
+        /// When the plug method has the same parameters as the original method, we dont have to generate or use any trampoline code
+        /// We can just change all calls to go directly to the plugged method
+        /// </summary>
+        public Dictionary<string, MethodBase> DirectPlugMapping = new Dictionary<string, MethodBase>();
 
         public PlugManager(Action<Exception> aLogException, Action<string> aLogWarning, TypeResolver typeResolver)
         {
@@ -165,11 +166,7 @@ namespace Cosmos.IL2CPU
                             {
                                 // Skip checking methods related to fields because it's just too messy...
                                 // We also skip methods which do method access.
-                                if (xMethod.GetParameters().Where(x =>
-                                {
-                                    return x.GetCustomAttributes(typeof(FieldAccess)).Any()
-                                           || x.GetCustomAttributes(typeof(ObjectPointerAccess)).Any();
-                                }).Any())
+                                if (PlugRequriesModifiedCall(xMethod))
                                 {
                                     OK = true;
                                 }
@@ -333,6 +330,18 @@ namespace Cosmos.IL2CPU
                 }
             }
         }
+
+        /// <summary>
+        /// Determines if the method requires any modificiation or addition of parameters compared to the plugged call
+        /// This includes special field accesses or modifing self to be a pointer
+        /// </summary>
+        /// <param name="xMethod"></param>
+        /// <returns></returns>
+        private static bool PlugRequriesModifiedCall(MethodInfo xMethod) => xMethod.GetParameters().Where(x =>
+        {
+            return x.GetCustomAttributes(typeof(FieldAccess)).Any()
+                   || x.GetCustomAttributes(typeof(ObjectPointerAccess)).Any();
+        }).Any();
 
         public Action<string> LogWarning;
 
@@ -638,7 +647,7 @@ namespace Cosmos.IL2CPU
 
         public MethodBase ResolvePlug(MethodBase aMethod, Type[] aParamTypes)
         {
-            var xMethodKey = BuildMethodKeyName(aMethod);
+            var xMethodKey = LabelName.GetFullName(aMethod);
             if (ResolvedPlugs.TryGetValue(xMethodKey, out var xResult))
             {
                 return xResult;
@@ -718,6 +727,17 @@ namespace Cosmos.IL2CPU
                 }
 
                 ResolvedPlugs[xMethodKey] = xResult;
+                // this data structure is used to track when we can skip the trampoline code when emitting the methods
+                // inline is some weird kind of plug, which require other handling
+                if (xResult != null && !PlugRequriesModifiedCall(xResult as MethodInfo) &&
+                    (xResult.GetCustomAttribute<InlineAttribute>() == null))
+                {
+                    if(LabelName.Get(xResult) == "SystemVoidCosmosDebugKernelPlugsAsmDebuggerAsmSendKernelPanicSystemUInt32")
+                    {
+                        int x = 0;
+                    }
+                    DirectPlugMapping[xMethodKey] = xResult;
+                }
 
                 return xResult;
             }

--- a/source/Cosmos.IL2CPU/PlugManager.cs
+++ b/source/Cosmos.IL2CPU/PlugManager.cs
@@ -732,11 +732,14 @@ namespace Cosmos.IL2CPU
                 if (xResult != null && !PlugRequriesModifiedCall(xResult as MethodInfo) &&
                     (xResult.GetCustomAttribute<InlineAttribute>() == null))
                 {
-                    if(LabelName.Get(xResult) == "SystemVoidCosmosDebugKernelPlugsAsmDebuggerAsmSendKernelPanicSystemUInt32")
+                    // we need to stop wildcard plugs because they have different naming schemes
+                    if(xResult.GetCustomAttribute<PlugMethod>()?.IsWildcard ?? false)
                     {
-                        int x = 0;
                     }
-                    DirectPlugMapping[xMethodKey] = xResult;
+                    else
+                    {
+                        DirectPlugMapping[xMethodKey] = xResult;
+                    }
                 }
 
                 return xResult;


### PR DESCRIPTION
Plugs will only call the trampoline code when required. When possible just change all calls to go the plug directly