### PR TITLE
Add CLI argument to disable X# comments

### DIFF
--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -1,5 +1,7 @@
 ﻿//#define COSMOSDEBUG
 
+using XSharp;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -67,6 +69,8 @@ namespace Cosmos.IL2CPU
         public CompilerEngine(ICompilerEngineSettings aSettings)
         {
             mSettings = aSettings;
+
+            XS.AllowComments = mSettings.AllowComments;
 
             #region Assembly Path Checks
 

--- a/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ConsoleCompilerEngineSettings.cs
@@ -44,6 +44,8 @@ namespace Cosmos.IL2CPU
         public bool CompileVBEMultiboot => GetOption<bool>(nameof(CompileVBEMultiboot));
         public string VBEResolution => GetOption<string>(nameof(VBEResolution));
 
+        public bool AllowComments => GetOption<bool>(nameof(AllowComments));
+
         public ConsoleCompilerEngineSettings(string[] aArgs, Action<string> aLogMessage, Action<string> aLogError)
         {
             mLogMessage = aLogMessage;

--- a/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
+++ b/source/Cosmos.IL2CPU/ICompilerEngineSettings.cs
@@ -29,5 +29,7 @@ namespace Cosmos.IL2CPU
         bool RemoveBootDebugOutput { get; }
         bool CompileVBEMultiboot { get; }
         string VBEResolution { get;  }
+
+        bool AllowComments { get; }
     }
 }


### PR DESCRIPTION
This PR adds a CLI argument to IL2CPU to disable X# comments. A Cosmos PR will come soon to add this argument to the build tasks as well, so that they can be enabled.