### PR TITLE
Fix ManifestResourceStream speed: Use assembler directive `incbin` instead of outputting the binary to the asm output

### DIFF
--- a/source/Cosmos.IL2CPU/AppAssembler.cs
+++ b/source/Cosmos.IL2CPU/AppAssembler.cs
@@ -42,6 +42,7 @@ namespace Cosmos.IL2CPU
         public DebugInfo DebugInfo { get; set; }
         private TextWriter mLog;
         private string mLogDir;
+        private string mOutputDir;
         private Dictionary<string, ModuleDefinition> mLoadedModules = new Dictionary<string, ModuleDefinition>();
         public TraceAssemblies TraceAssemblies;
         public bool DebugEnabled = false;
@@ -51,13 +52,15 @@ namespace Cosmos.IL2CPU
         public bool IgnoreDebugStubAttribute;
         private List<MethodIlOp> mSymbols = new List<MethodIlOp>();
         private List<INT3Label> mINT3Labels = new List<INT3Label>();
+        private int incBinCounter = 0;
         public readonly CosmosAssembler Assembler;
         
-        public AppAssembler(CosmosAssembler aAssembler, TextWriter aLog, string aLogDir)
+        public AppAssembler(CosmosAssembler aAssembler, TextWriter aLog, string aLogDir, string aOutputDir)
         {
             Assembler = aAssembler;
             mLog = aLog;
             mLogDir = aLogDir;
+            mOutputDir = aOutputDir;
             InitILOps();
         }
 
@@ -1142,9 +1145,13 @@ namespace Cosmos.IL2CPU
                         xStream.Read(xData, 16, (int)xStream.Length);
                     }
 
-                    XS.DataMemberBytes(xFieldContentsName, xData);
+                    File.WriteAllBytes(Path.Join(mOutputDir, "bin" + incBinCounter + ".bin"), xData);
+
+                    XS.DataMember(xFieldContentsName, "bin" + incBinCounter + ".bin", true);
                     XS.DataMember(xFieldName, 1, "dd", "0");
                     XS.DataMember("", 1, "dd", xFieldContentsName);
+
+                    incBinCounter++;
 
                     //Assembler.DataMembers.Add(new DataMember(xFieldContentsName, "db", xTarget.ToString()));
                     //Assembler.DataMembers.Add(new DataMember(xFieldName, "dd", xFieldContentsName));

--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -237,7 +237,7 @@ namespace Cosmos.IL2CPU
             var assemblerLogFile = Path.Combine(Path.GetDirectoryName(mSettings.OutputFilename), AssemblerLog);
             Directory.CreateDirectory(Path.GetDirectoryName(assemblerLogFile));
             StreamWriter mLog = new(File.OpenWrite(assemblerLogFile));
-            return new AppAssembler(new CosmosAssembler(debugCom), mLog, Path.GetDirectoryName(assemblerLogFile));
+            return new AppAssembler(new CosmosAssembler(debugCom), mLog, Path.GetDirectoryName(assemblerLogFile), Path.GetDirectoryName(mSettings.OutputFilename));
         }
 
         #region Gen2

--- a/tests/IL2CPU.Compiler.Tests/ILStackAnalysisTests.cs
+++ b/tests/IL2CPU.Compiler.Tests/ILStackAnalysisTests.cs
@@ -71,7 +71,7 @@ namespace IL2CPU.Compiler.Tests
             var method = aType.GetMethod(aMethodName, 0, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static, null, aArgs, null);
             var methodBase = new Il2cpuMethodInfo(method, 1, Il2cpuMethodInfo.TypeEnum.Normal, null);
 
-            var appAssembler = new AppAssembler(null, new VoidTextWriter(), "")
+            var appAssembler = new AppAssembler(null, new VoidTextWriter(), "", "")
             {
                 DebugMode = Cosmos.Build.Common.DebugMode.None
             };
@@ -105,7 +105,7 @@ namespace IL2CPU.Compiler.Tests
             var method = aType.GetMethod(aMethodName, 0, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static, null, aArgs, null);
             var methodBase = new Il2cpuMethodInfo(method, 1, Il2cpuMethodInfo.TypeEnum.Normal, null);
 
-            var appAssembler = new AppAssembler(null, new VoidTextWriter(), "")
+            var appAssembler = new AppAssembler(null, new VoidTextWriter(), "", "")
             {
                 DebugMode = Cosmos.Build.Common.DebugMode.None
             };


### PR DESCRIPTION
Fixes ManifestResourceStreams speed using the `incbin` NASM/YASM assembler directive. This includes binary directly from an external file which is a lot faster than using a huge `db` instruction.

30mb file:
```
Before:
  1>IL2CPU task took 00:00:36.5974656
  1>-g dwarf2 -f elf -o bin\Debug\net6.0\nxtlvlOS.obj -dELF_COMPILATION -O2 bin\Debug\net6.0\nxtlvlOS.asm
  1>Yasm task took 00:06:10.1939569
```

```
After:
  1>IL2CPU task took 00:00:23.8534121
  1>-g dwarf2 -f elf -o bin\Debug\net6.0\nxtlvlOS.obj -dELF_COMPILATION -O2 bin\Debug\net6.0\nxtlvlOS.asm
  1>Yasm task took 00:00:10.8834183
```