### PR TITLE
Improve error message for missing plugs

### DIFF
--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -559,8 +559,7 @@ namespace Cosmos.IL2CPU
                 }
                 if (xNeedsPlug)
                 {
-                    throw new Exception(Environment.NewLine
-                        + "Native code encountered, plug required." + Environment.NewLine
+                    throw new Exception("Native code encountered, plug required. Check build output for more information." + Environment.NewLine
                                         + "  DO NOT REPORT THIS AS A BUG." + Environment.NewLine
                                         + "  Please see http://www.gocosmos.org/docs/plugs/missing/" + Environment.NewLine
                         + "  Need plug for: " + LabelName.GetFullName(aMethod) + "(Plug Signature: " + DataMember.FilterStringForIncorrectChars(LabelName.GetFullName(aMethod)) + " ). " + Environment.NewLine


### PR DESCRIPTION
Removed the newline and added a note that you should check the build output for more information, hopefully reducing the amount of "Getting useless System.Exception" blablabla issues and discord threads