### PR TITLE
Fix loading of packed structure

### DIFF
--- a/source/Cosmos.IL2CPU/IL/Stfld.cs
+++ b/source/Cosmos.IL2CPU/IL/Stfld.cs
@@ -46,7 +46,7 @@ namespace Cosmos.IL2CPU.X86.IL
 
             XS.Comment("After Nullref check");
 
-            // Determine field in obejct position
+            // Determine field in object position
             if (aNeedsGC)
             {
                 XS.Set(ECX, ESP, sourceDisplacement: (int)xRoundedSize + 4);


### PR DESCRIPTION
The issue was that we were pushing the remainder at the end when loading, this caused the values to be aligned differently after a ldfld.