### PR TITLE
Implement ForceInclude Attribute

### DIFF
--- a/source/Cosmos.IL2CPU/ExceptionHelper.cs
+++ b/source/Cosmos.IL2CPU/ExceptionHelper.cs
@@ -47,7 +47,6 @@ namespace Cosmos.IL2CPU
         public static void ThrowInvalidCastException() => throw new InvalidCastException();
     }
 
-    [ForceInclude]
     public static class ExceptionHelperRefs
     {
         public static readonly FieldInfo CurrentExceptionRef = typeof(ExceptionHelper).GetField("CurrentException");


### PR DESCRIPTION
To use this you will need to add the ForceInclude attribute to the GCImplementation and  Vtable types.

This have 2 downsides:

1. Increment compile time.
2. It doesn't handle generics, so if you try to use the attribute on a class with public Generic methods or on a generic method itself, then IL2CPU would probably throw